### PR TITLE
Added default README.md and License.md

### DIFF
--- a/License.md
+++ b/License.md
@@ -1,0 +1,8 @@
+The MIT License (MIT)
+Copyright (c) 2016
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.

--- a/README.md
+++ b/README.md
@@ -1,0 +1,29 @@
+## Synopsis
+
+Threadly is a commenting service exercise created by [Code Academy](https://discuss.codecademy.com/t/about-the-threadly-category/3524). This is an implementation by [Georgelle](https://github.com/Georgelle)
+
+## Code Example
+
+The main piece of JavaScript is a [jQuery](http://jquery.com/) submit (event handler)[https://learn.jquery.com/events/handling-events/] that adds a comment upon submission.
+
+## Motivation
+
+The purpose of this exercise is to show how jQuery can be used to respond to events.
+
+## Installation
+
+Download the repository and open the index.html page in the browser.
+
+
+## Tests
+
+There are no tests on this project at the moment, but that is something that can/will be added in the future
+
+## Contributors
+
+* [Georgelle](https://github.com/Georgelle)
+* [trystant](https://github.com/trystant)
+
+## License
+
+see [License](file:///License.md)


### PR DESCRIPTION
- License.md - Added MIT License
- README.md - Created default README.md template that better explains
  why this project exists.

Updates issues [1](https://github.com/trystant/threadly/issues/1) and [2](https://github.com/trystant/threadly/issues/2)
Check on the issues associated with my [fork](https://github.com/trystant/threadly) for more detailed explanation, but I basically added a README and a LICENSE to start with in order to make your repo more complete.
